### PR TITLE
Show details of order

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,6 +10,7 @@ class ProfileController extends BaseController
     {
         $user = Auth::user();
         $orders = $user->orders;
+        dd($orders);
         return view('profile.index', $this->bindParams([
             'user' => $user,
             'address' => $user->defaultAddress,

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -10,7 +10,7 @@ class ProfileController extends BaseController
     {
         $user = Auth::user();
         $orders = $user->orders;
-        dd($orders);
+
         return view('profile.index', $this->bindParams([
             'user' => $user,
             'address' => $user->defaultAddress,

--- a/app/Http/Controllers/RetailerController.php
+++ b/app/Http/Controllers/RetailerController.php
@@ -34,8 +34,9 @@ class RetailerController extends Controller
         # Get all orders assigned to retailer
         $ordersArray = [];
         foreach ($orderProductsArray as $orderProduct) {
-
+    
             array_push($ordersArray, $orderProduct->order);
+            $ordersArray = array_unique($ordersArray);
         }
         
         # Get all users that ordered a car assigned to our retailer
@@ -43,7 +44,7 @@ class RetailerController extends Controller
         foreach ($ordersArray as $order) {
             array_push($userArray, $order->user);
         }
-    
+
 
 
        

--- a/resources/views/checkout/summary.blade.php
+++ b/resources/views/checkout/summary.blade.php
@@ -3,10 +3,10 @@
     <div class="container-lg">
         <div class="steps row cart-body">
             <h2>Zamówienie złożone</h2>
-            <p>Dziekujemy, Panstwa zamowienie zostalo zlozone. Identyfikator zamowienia: <span class="badge badge-default">{{ $order->id }}</span></p>
+            
         </div>
         <div class="row cart-footer">
-
+            <p>Dziekujemy, Panstwa zamowienie zostalo zlozone. Identyfikator zamowienia: <span class="badge badge-default">{{ $order->id }}</span></p>
         </div>
     </div>
 @endsection

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -74,8 +74,21 @@
                                             @endforeach
                                             </tbody>
                                         </table>
+                                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#order_data_{{ $order->id }}" aria-expanded="true" aria-controls="collapseTwo">Szczegóły zamówienia</button>
                                     </div>
+                                    <div id="order_data_{{ $order->id }}" class="collapse" aria-labelledby="headingOne" data-parent="#order{{ $order->id }}">
+                                        <div class="card-body">
+                                            <h3>Dane zamawiającego</h3>
+                                            <p>Imię i Nazwisko: <span class="badge">{{ $order->name }} {{ $order->surname }} </span></p>
+                                            <p>Numer domu: <span class="badge">{{ $order->house_number }}/{{ $order->local_number }}</span> </p>
+                                            <p>Ulica: <span class="badge">{{ $order->street }}</span></p>
+                                            <p>Kod pocztowy: <span class="badge">{{ $order->postcode }}</span></p>
+                                            <p>Miasto: <span class="badge">{{ $order->city }}</span></p>
+                                        </div>
+                                    </div>
+                                    
                                 </div>
+                                
                             </div>
                         @endforeach
                     </div>

--- a/resources/views/retailer/index.blade.php
+++ b/resources/views/retailer/index.blade.php
@@ -42,11 +42,9 @@
                                         @method('PATCH') 
                                         <p>Zmiana statusu zamówienia
                                             <select id="status" name="status"> 
-                                                    <option value="noChange">{{ $order -> status}}</option>       
-                                                    <option value="Nowe">Nowe</option>
-                                                    <option value="Realizacja">Realizacja</option>
-                                                    <option value="Dostawa">Dostawa</option>
-                                                    <option value="Zakończone">Zakończone</option>
+                                                    @foreach (\App\Order::getStatuses() as $key => $method)
+                                                        <option value="{{ $key }}">{{ $method }}</option>
+                                                    @endforeach
                                             </select>
                                             <button type="submit" class="btn btn-primary">Zapisz</button>
                                             </p>

--- a/resources/views/retailer/index.blade.php
+++ b/resources/views/retailer/index.blade.php
@@ -53,8 +53,9 @@
                                             <thead>
                                                 <tr>
                                                     <th scope="col">#</th>
-                                                    <th scope="col" >Nazwa produktu</th>
-                                                    <th scope="col" >Kategoria</th>
+                                                    <th scope="col">Nazwa produktu</th>
+                                                    <th scope="col">ID produktu</th>
+                                                    <th scope="col">Kategoria</th>
                                                     <th scope="col">Cena</th>
                                                     <th scope="col">Rocznik</th>
                                                     <th scope="col">Kolor</th>
@@ -71,6 +72,7 @@
                                                 <tr>
                                                    <td>{{ $i = $i+1 }}</td>
                                                    <td>{{ $orderProduct->product->name }}</td>
+                                                   <td>{{ $orderProduct->product->id }}</td>
                                                    <td>{{ $orderProduct->product->category->name }}</td>
                                                    <td>{{ $orderProduct->product->price }}</td>
                                                    <td>{{ $orderProduct->product->year }}</td>

--- a/resources/views/retailer/index.blade.php
+++ b/resources/views/retailer/index.blade.php
@@ -10,84 +10,104 @@
                 <p>{{ $user -> name }} {{ $user -> surname }}</p>
             </div>
             <div class="col-10">
-                <h2>Zamówienia</h2>
 
-                @if(session('success'))
+            <h2>Zamówienia</h2>
+            @if(session('success'))
                 <div class="alert alert-success" id="success-alert">
                     <button type="button" class="close" data-dismiss="alert">x</button>
                     <strong>Zaktualizowano! </strong> Status zamówienia został zmieniony.
                 </div>
-                @endif
-                    <table class="table">
-                    <thead>
-                        <tr>
-                        <th scope="col" class="text-center">Nr</th>
-                        <th scope="col" class="text-center" style="width:20%">Imię i nazwisko klienta</th>
-                        <th scope="col" class="text-center" style="width:10%;">ID produktu</th>
-                        <th scope="col" class="text-center" style="width:11%">Marka</th>
-                        <th scope="col" class="text-center" style="width:11%">Model</th>
-                        <th scope="col" class="text-center" style="width:11%">Cena</th>
-                        <th scope="col" class="text-center" style="width:10%">Metoda płatności</th>
-                        <th scope="col" class="text-center" style="width:10%">Status</th>
-                        <th scope="col" class="text-center" style="width:10%">Akcja</th>
-                        </tr>
-                    </thead>
-                    </table>
+            @endif
+            @if ($orders)
+                    <div class="accordion" id="accordionExample">
+                        @foreach ($orders as $order)
+                            <div class="card">
+                                <div class="card-header" id="headingOne">
+                                    <h2 class="mb-0">
+                                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#order{{ $order->id }}" aria-expanded="true" aria-controls="collapseOne">
+                                            Zamówienie o id: <span class="badge badge-info">{{ $order->id }}</span>
+                                            Utworzone <span class="badge badge-success">{{ $order->created_at->diffForHumans() }}</span>
+                                            <!-- Utworzone <span class="badge badge-success"></span> -->
+                                        </button>
+                                    </h2>
+                                </div>
 
-                    
-                    
-                    @php
-                        $i = 0;
-                    @endphp
-                
-                    @foreach ($orders as $order)   
-                    <form method="POST" action="/retailer/order/{{$order->id}}">
-                    @csrf
-                    @method('PATCH') 
-                        <div id="accordionExample">
-                        <table class="table">
-                            <tbody>
-                                <tr>
-                                    <th class="text-center" scope="row">{{ $i+1 }}</th>
-                                    <td class="text-center" style="width:20%">{{ $clients[$i] -> name }} {{ $clients[$i] -> surname }}</td>
-                                    <td class="text-center" style="width:10%;">{{ $orderProducts[$i]->product->id }}</td>
-                                    <td class="text-center" style="width:11%">{{ $orderProducts[$i]->product->category->name }}</td>
-                                    <td class="text-center" style="width:11%">{{ $orderProducts[$i]->product->name }}</td>
-                                    <td class="text-center" style="width:11%">{{ $orderProducts[$i]->product->price}} PLN</td>
-                                    <td class="text-center" style="width:10%">{{ $order -> payment_method }}</td>
+                                <div id="order{{ $order->id }}" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+                                    <div class="card-body">
+                                        <p>Metoda płatnosci: <span class="badge">{{ $order->getFormattedPaymentMethod() }}</span></p>
+                                        <p>Miejsce odbioru: <span class="badge">{{ $order->getFormattedRecollectionMethod() }}</span></p>
+                                        <p>Status zamówienia: <span class="badge">{{ $order->getFormattedStatus() }}</span></p>
+                                        <form method="POST" action="/retailer/order/{{$order->id}}">
+                                        @csrf
+                                        @method('PATCH') 
+                                        <p>Zmiana statusu zamówienia
+                                            <select id="status" name="status"> 
+                                                    <option value="noChange">{{ $order -> status}}</option>       
+                                                    <option value="Nowe">Nowe</option>
+                                                    <option value="Realizacja">Realizacja</option>
+                                                    <option value="Dostawa">Dostawa</option>
+                                                    <option value="Zakończone">Zakończone</option>
+                                            </select>
+                                            <button type="submit" class="btn btn-primary">Zapisz</button>
+                                            </p>
+                                        </form>
+                                        <table class="table">
+                                            <thead>
+                                                <tr>
+                                                    <th scope="col">#</th>
+                                                    <th scope="col" >Nazwa produktu</th>
+                                                    <th scope="col" >Kategoria</th>
+                                                    <th scope="col">Cena</th>
+                                                    <th scope="col">Rocznik</th>
+                                                    <th scope="col">Kolor</th>
+                                                    <th scope="col">Silnik</th>
+                                                    <th scope="col">Typ</th>
+                                                    <th scope="col">Skrzynia</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                            @php
+                                                $i = 0;
+                                            @endphp
+                                            @foreach ($order->orderProducts as $orderProduct)
+                                                <tr>
+                                                   <td>{{ $i = $i+1 }}</td>
+                                                   <td>{{ $orderProduct->product->name }}</td>
+                                                   <td>{{ $orderProduct->product->category->name }}</td>
+                                                   <td>{{ $orderProduct->product->price }}</td>
+                                                   <td>{{ $orderProduct->product->year }}</td>
+                                                   <td>{{ $orderProduct->product->color }}</td>
+                                                   <td>{{ $orderProduct->product->engine }}</td>
+                                                   <td>{{ $orderProduct->product->body_type }}</td>
+                                                   <td>{{ $orderProduct->product->gearbox }}</td>
+                                                </tr>
+                                            @endforeach
+                                            </tbody>
+                                        </table>
+                                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#order_data_{{ $order->id }}" aria-expanded="true" aria-controls="collapseTwo">Szczegóły zamówienia</button>
+                                    </div>
+                                    <div id="order_data_{{ $order->id }}" class="collapse" aria-labelledby="headingOne" data-parent="#order{{ $order->id }}">
+                                        <div class="card-body">
+                                            <h3>Dane zamawiającego</h3>
+                                            <p>Imię i Nazwisko: <span class="badge">{{ $order->name }} {{ $order->surname }} </span></p>
+                                            <p>Numer domu: <span class="badge">{{ $order->house_number }}/{{ $order->local_number }}</span> </p>
+                                            <p>Ulica: <span class="badge">{{ $order->street }}</span></p>
+                                            <p>Kod pocztowy: <span class="badge">{{ $order->postcode }}</span></p>
+                                            <p>Miasto: <span class="badge">{{ $order->city }}</span></p>
+                                        </div>
+                                    </div>
                                     
-                                    <td class="form-group text-center" style="width:10%">
-                                        <select id="status" name="status"> 
-                                                <option value="noChange">{{ $order -> status}}</option>       
-                                                <option value="Nowe">Nowe</option>
-                                                <option value="Realizacja">Realizacja</option>
-                                                <option value="Dostawa">Dostawa</option>
-                                                <option value="Zakończone">Zakończone</option>
-                                        </select>
-                                    </td>       
-                                    <td class="form-group text-center" style="width:10%">
-                                        <button type="submit" class="btn btn-primary">Zapisz</button>
-                                    </td>
-                                </tr>
-                                @php
-                                    $i++;
-                                @endphp
-                            </tbody>
-                        </table>
-                        </div>
-                    </form>
-                    <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#order{{ $order->id }}" aria-expanded="true" aria-controls="collapseOne">Szczegóły zamówienia</button>
-                    <div id="order{{ $order->id }}" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
-                        <div class="card-body">
-                            <h3>Dane zamawiającego</h3>
-                            <p>Imię i Nazwisko: <span class="badge">{{ $order->name }} {{ $order->surname }} </span></p>
-                            <p>Numer domu: <span class="badge">{{ $order->house_number }}/{{ $order->local_number }}</span> </p>
-                            <p>Ulica: <span class="badge">{{ $order->street }}</span></p>
-                            <p>Kod pocztowy: <span class="badge">{{ $order->postcode }}</span></p>
-                            <p>Miasto: <span class="badge">{{ $order->city }}</span></p>
-                        </div>
+                                </div>
+                                
+                            </div>
+                        @endforeach
                     </div>
-                    @endforeach
+                @else
+                    <p>Nie masz adnych zamówień</p>
+                @endif
+
+
+                
             </div>
         </div>
     </div>

--- a/resources/views/retailer/index.blade.php
+++ b/resources/views/retailer/index.blade.php
@@ -44,6 +44,7 @@
                     <form method="POST" action="/retailer/order/{{$order->id}}">
                     @csrf
                     @method('PATCH') 
+                        <div id="accordionExample">
                         <table class="table">
                             <tbody>
                                 <tr>
@@ -73,7 +74,19 @@
                                 @endphp
                             </tbody>
                         </table>
+                        </div>
                     </form>
+                    <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#order{{ $order->id }}" aria-expanded="true" aria-controls="collapseOne">Szczegóły zamówienia</button>
+                    <div id="order{{ $order->id }}" class="collapse" aria-labelledby="headingOne" data-parent="#accordionExample">
+                        <div class="card-body">
+                            <h3>Dane zamawiającego</h3>
+                            <p>Imię i Nazwisko: <span class="badge">{{ $order->name }} {{ $order->surname }} </span></p>
+                            <p>Numer domu: <span class="badge">{{ $order->house_number }}/{{ $order->local_number }}</span> </p>
+                            <p>Ulica: <span class="badge">{{ $order->street }}</span></p>
+                            <p>Kod pocztowy: <span class="badge">{{ $order->postcode }}</span></p>
+                            <p>Miasto: <span class="badge">{{ $order->city }}</span></p>
+                        </div>
+                    </div>
                     @endforeach
             </div>
         </div>

--- a/scripts/15-products.json
+++ b/scripts/15-products.json
@@ -10,7 +10,7 @@
         "color": "Srebny", 
         "body_type": "Van", 
         "engine": "Hybryda", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     }
     ,
     {"name": "Challenger", 
@@ -24,7 +24,7 @@
         "color": "Pomarańczowy", 
         "body_type": "Coupe", 
         "engine": "Benzynowy", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     }
     ,
     {"name": "Viper", 
@@ -52,7 +52,7 @@
         "color": "Żółty", 
         "body_type": "Suv", 
         "engine": "Diesel", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     }
     ,
     {"name": "Fiesta", 
@@ -65,7 +65,7 @@
         "retailer_id": 1, 
         "color": "Niebieski", 
         "body_type": "Hatchback", 
-        "engine": "Benzyna", 
+        "engine": "Benzynowy", 
         "gearbox": "Manualna"
     }
     ,
@@ -79,8 +79,8 @@
         "retailer_id": 1, 
         "color": "Niebieski", 
         "body_type": "Pickup", 
-        "engine": "Benzyna", 
-        "gearbox": "Automat"
+        "engine": "Benzynowy", 
+        "gearbox": "Automatyczna"
     }
     ,
     {"name": "Mustang", 
@@ -93,7 +93,7 @@
         "retailer_id": 1, 
         "color": "Czarny", 
         "body_type": "Coupe", 
-        "engine": "Benzyna", 
+        "engine": "Benzynowy", 
         "gearbox": "Manualna"
     }
     ,
@@ -108,7 +108,7 @@
         "color": "Biały", 
         "body_type": "Suv", 
         "engine": "Benzynowy", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     }
     ,
     {"name": "Savana", 
@@ -178,7 +178,7 @@
         "color": "Biały", 
         "body_type": "Sedan", 
         "engine": "Elektryczny", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     },
     {"name": "Model 3", 
         "description": "Model 3 jest samochodem w pełni elektrycznym. Oficjalna prezentacja miała miejsce 31 marca 2016 roku, a oficjalne wydawanie aut nastąpiło 28 lipca 2017 roku", 
@@ -191,7 +191,7 @@
         "color": "Czerwony", 
         "body_type": "Sedan", 
         "engine": "Elektryczny", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     }
     ,
     {"name": "Model X", 
@@ -205,7 +205,7 @@
         "color": "Czarny", 
         "body_type": "Suv", 
         "engine": "Elektryczny", 
-        "gearbox": "Automat"
+        "gearbox": "Automatyczna"
     }
     
     ]


### PR DESCRIPTION
Recent corrections:
- In /retailer and /profile we can see details of orders (address assigned to order)
- Change layout of /retailer. Now it's looks like /profile
- Repair sending value of order status in /retailer. Now it is based on collection 'statuses' in Order
- In 15-products.json change values of 'Benzyna' to 'Benzynowy' and 'Automat' to 'Automatyczna'
- Repair design in summary.blade